### PR TITLE
Make install instructions more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,70 @@ It handles all 4 methods styled components uses to create components. All of the
 -Visible, non-interactive elements with click handlers must have at least one keyboard listener.`
 ```
 
-```
+```jsx
 const Div = styled.div``;
 <Div onClick={() => null}/>
 ```
 
-```
+```jsx
 const Div = styled.div.attrs({ onClick: () => null})``;
 <Div />
 ```
 
-```
+```jsx
 const Div = styled.div.attrs({ onClick: () => null})``;
 const StyledDiv = styled(Div)``;
 <StyledDiv />
 ```
 
-```
+```jsx
 const ButtonAsDiv = styled.button``;
 <ButtonAsDiv as="div" onClick={() => null} />
 ```
 
 ![linting examples](https://github.com/brendanmorrell/styled-components-a11y-example/blob/master/example.png)
+
+## Installation
+
+Install as a dev dependency:
+
+    yarn add -D eslint-plugin-styled-components-a11y
+
+or
+
+    npm i --save-dev eslint-plugin-styled-components-a11y
+    
+### Configuration
+
+Add styled-components-a11y to the plugins section of your .eslintrc configuration file. You can omit the eslint-plugin- prefix:
+
+```json
+{
+  "plugins": [
+    "styled-components-a11y"
+  ]
+}
+```
+
+Enable the recommeded ruleset or the strict ruleset. Add `plugin:styled-components-a11y/recommended` or `plugin:styled-components-a11y/strict` in extends:
+
+```json
+{
+  "extends": [
+    "plugin:styled-components-a11y/recommended"
+  ]
+}
+```
+
+Alternatively, you can configure individual rules under the rules section.
+
+```json
+{
+  "rules": {
+    "styled-components-a11y/rule-name": 2
+  }
+}
+```
 
 ## Examples
 
@@ -50,39 +92,6 @@ Most modern sites are almost entirely unnavigable for those with special needs. 
 1. version 0.0.15 had two major bug fixes, if you have a previous version, please update.
 2. As evidence of the importance of styled a11y linting, I ran just this plugin on a prod repo i'm working on, and it uncovered 6,567 errors that were undiscovered using airbnb/jsx-a11y linting rules. once again, please share, star the [github repo](https://github.com/brendanmorrell/eslint-plugin-styled-components-a11y), report any bugs, and please conribute so we can increase web accessibility for all!
 
-## Usage
-
-Install as a dev dependency using `yarn add eslint-plugin-styled-components-a11y -D` or `npm i eslint-plugin-styled-components-a11y --save-dev` and
-add styled-components-a11y to the plugins section of your .eslintrc configuration file. You can omit the eslint-plugin- prefix:
-
-```
-{
-  "plugins": [
-    "styled-components-a11y"
-  ]
-}
-```
-
-Enable the recommeded ruleset or the strict ruleset. Add `plugin:styled-components-a11y/recommended` or `plugin:styled-components-a11y/strict` in extends:
-
-```
-{
-  "extends": [
-    "plugin:styled-components-a11y/recommended"
-  ]
-}
-```
-
-Alternatively, you can configure individual rules under the rules section.
-
-```
-{
-  "rules": {
-  "styled-components-a11y/rule-name": 2
-  }
-}
-```
-
 ## Contributing
 
 Contributions are very welcome, as I don't have a lot of free time to work on this currently. My personal todo list is in Todo.md. I will try to make this more intelligible to other contributors, but if you'd like to start before I get around to that, let me know, and I can tell you what still needs work. Thanks!
@@ -96,7 +105,7 @@ Here are the broad strokes in order of priority:
 1. I want to have all the rules running more test cases. Make sure that the test passes with all the different forms styled components can handle  (styled.{html tag}, styled.{html tag}.attrs() styled(Component)``, and <Component as="{some other tag}"). I have a helper function that already creates all of these test cases for you. You basically tell it the tag, the attrs, the props, the children, and the error (all of these are strings and are optional). For example, this would create an array of the following strings that you could then run tests on to make sure the correct linter rule fired:
    This:
 
-```
+```jsx
 
 const clickKeyDown = makeStyledTestCases({
 tag: 'a',
@@ -111,7 +120,7 @@ would create an array of objects with the key 'code' having the following string
 
 - (tag is set to a, props is the string from 'props', and children are present inside styled component)
 
-```
+```jsx
 
 const FUNC = styled.a``;
 const Component = () => <FUNC onClick={() => 0} onKeyDown={foo}>some text</FUNC>
@@ -120,7 +129,7 @@ const Component = () => <FUNC onClick={() => 0} onKeyDown={foo}>some text</FUNC>
 
 - (tag is set to a, attrs is the string from 'attrs', and children are present inside styled component)
 
-```
+```jsx
 
 const FUNC = styled.a.attrs({ onClick:() => 0, onKeyDown: foo })``;
 const Component = () => <Component>some text</Component>
@@ -129,7 +138,7 @@ const Component = () => <Component>some text</Component>
 
 - the same thing but using an extended component
 
-```
+```jsx
 
 const FUNC = styled.a.attrs({ onClick:() => 0, onKeyDown: foo })`; const Extended = styled(FUNC)`;
 const Component = () => <Extended>some text</Extended>
@@ -138,7 +147,7 @@ const Component = () => <Extended>some text</Extended>
 
 - the same thing but with the as prop (the initial component is just anything other than what you put in as the tag)
 
-```
+```jsx
 
 const FUNC = styled.div.attrs({ onClick:() => 0, onKeyDown: foo })`; const Extended = styled(FUNC)`;
 const Component = () => <Extended as="a">some text</Extended>
@@ -149,13 +158,13 @@ to test error cases, you add the errors parameter to makeStyledTestCases, which 
 
 See if you can add some more rules. When the rules error out, best bet is to log whatever the failing role is, and then take all those test cases, paste them into a project that is running eslint-plugin-styled-components-a11y, and just trace the code to see why it is either firing when it shouldn't or not firing when it should. The way i have been doing this (which is kind of painful) is to go into your node_modules and start by just getting the rule to fire. for this you either want to look in src/collectStyledComponentData.js (if the problem is with collecting the data for the styled component), or more frequently in the relevant parser file in src/nodeParsers. Look at src/ruleNameToTypeDict to see what parser goes with what rule. When you have the right file, i generally start out by just getting the linter to fire off with a hello world. Each parser file has a helper function in it called 'func'. it looks like this:
 
-```
+```jsx
 const func = inspectee => name.includes('scope') && context.report(node, inspect(inspectee || node));
 ```
 
 put the name of the rule in where the example says 'scope' (so it only runs once for that rule instead of on every rule) and call it with either the node you want to log (which is what eslint is parsing. it runs over every node in the code's abstract syntax tree and calls your lining rules), or anything else you want to log. immediately after you run fund (at first, at the top of the file), add a return statement, as sometimes the linter is erroring out, and thus won't log unless you short-circuit it before the error. For example, if i were testing the rule accessible-emoji i would have the following to start:
 
-```
+```jsx
 const func = inspectee => name.includes('accessible-emoji') && context.report(node, inspect(inspectee || node));
 fund('hello world');
 return;
@@ -167,7 +176,7 @@ When you reload your editor (this is necessary unfortunately), you should see he
 
 3. there are a lot of edge cases in terms of both the function and arrow function syntax for attrs (e.g.,
 
-````
+````jsx
 styled.div.attrs(p => p.large ? ({foo:'bar', baz: p.small ? 1 : 2}))``;```
 ````
 


### PR DESCRIPTION
I shifted the installation instructions higher up in the README and made it easer for people to copy and paste.

Also snuck in some syntax highlighting for your code samples.