### PR TITLE
restrict airbnb rules to just a11y specfic ones

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ module.exports = {
   configs: {
     recommended: {
       plugins: ['styled-components-a11y'],
-      extends: ['eslint-config-airbnb'],
+      extends: ['eslint-config-airbnb/rules/react-a11y'],
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
@@ -156,7 +156,7 @@ module.exports = {
     },
     strict: {
       plugins: ['styled-components-a11y'],
-      extends: ['eslint-config-airbnb'],
+      extends: ['eslint-config-airbnb/rules/react-a11y'],
       parserOptions: {
         ecmaFeatures: {
           jsx: true,


### PR DESCRIPTION
Using the configurations provided by eslint-plugin-styled-components-a11y adds a bunch of unrelated rules from the airbnb configuration such as whitespacing, etc.

This PR limits the scope of the airbnb rules