### PR TITLE
Support for styled components defined after use

### DIFF
--- a/__tests__/rules/aria-props.test.js
+++ b/__tests__/rules/aria-props.test.js
@@ -41,6 +41,19 @@ const Func = () => (
   </>
 );
 `;
+
+const validNormalReverseOrder = `
+const Func = () => (
+  <>
+    <StyledDiv id="address_label">Enter your address</StyledDiv>
+    <StyledInput aria-labelledby="address_label" />
+  </>
+);
+
+const StyledDiv = styled.div\`\`;
+const StyledInput = styled.input\`\`;
+`;
+
 const validAttrs = `
 const StyledDiv = styled.div.attrs({ id: 'address_label' })\`\`;
 const StyledInput = styled.input.attrs({ 'aria-labelledby': 'address_label' })\`\`;
@@ -81,7 +94,7 @@ const Func = () => (
 );
 `;
 
-const valid = [validNormal, validAttrs, validComponent, validAs].map(code => ({ code })).map(parserOptionsMapper);
+const valid = [validNormal, validAttrs, validComponent, validAs, validNormalReverseOrder].map(code => ({ code })).map(parserOptionsMapper);
 
 // ## INVALID
 // <div id="address_label">Enter your address</div>
@@ -137,7 +150,22 @@ const Func = () => (
 );
 `;
 
-const invalid = [invalidNormal, invalidAttrs, invalidComponent, invalidAs]
+const invalidInReverseOrder = `
+const Func = () => (
+  <>
+    <StyledNotCompDiv as="div">Enter your address</StyledNotCompDiv>
+    <StyledNotCompInput as="input" aria-labeledby="address_label" />
+  </>
+);
+
+const StyledNotDiv = styled.button.attrs({ id: 'address_label' })\`\`;
+const StyledInput = styled.button.attrs({ 'aria-labeledby': 'address_label' })\`\`;
+
+const StyledNotCompDiv = styled(StyledNotDiv)\`\`;
+const StyledNotCompInput = styled(StyledInput)\`\`;
+`;
+
+const invalid = [invalidNormal, invalidAttrs, invalidComponent, invalidAs, invalidInReverseOrder]
   .map(code => ({ code, errors: [errorMessage('aria-labeledby')] }))
   .map(parserOptionsMapper);
 
@@ -145,6 +173,7 @@ const invalid = [invalidNormal, invalidAttrs, invalidComponent, invalidAs]
 invalid[1].errors.push(errorMessage('aria-labeledby'));
 invalid[2].errors.push(errorMessage('aria-labeledby'));
 invalid[3].errors.push(errorMessage('aria-labeledby'));
+invalid[4].errors.push(errorMessage('aria-labeledby'));
 
 ruleTester.run(ruleName, rule, {
   valid,

--- a/src/utils/makeRule.js
+++ b/src/utils/makeRule.js
@@ -13,9 +13,20 @@ module.exports = (name) => ({
     const nodeParserPath = path.join(__dirname, 'nodeParsers', ruleNameToTypeDict[name]);
     const rule = rules[name];
     const styledComponents = {};
+    const nodesArray = [];
+    const parserMapping = {
+      JSXOpeningElement: 'JSXOpeningElement',
+      JSXElement: 'JSXElement',
+      JSXAttribute: 'JSXOpeningElement'
+    };
+    const parsedElement = parserMapping[ruleNameToTypeDict[name]];
     return {
-      ...collectStyledComponentData(styledComponents, context, name),
-      ...require(nodeParserPath)(context, styledComponents, rule, name),
+      ...(collectStyledComponentData(styledComponents, context, name)),
+      [parsedElement]: (node) => nodesArray.push(node),
+      "Program:exit": () => {
+        const parser = require(nodeParserPath)(context, styledComponents, rule, name);
+        nodesArray.forEach((node) => parser[parsedElement](node))
+      }
     };
   },
 });


### PR DESCRIPTION
## The problem

Consider the following piece of code:

```
const StyledSpan = styled.span``;
const MyComponent = () => <StyledSpan onClick={() => console.log("Hello")}>Hello</StyledSpan>;
```

This linter detects that onClick is attached to a span element which it should not, an error is reported.

But some people, myself included, prefer to define styled components after the main component. Whether this is good or bad practice is a separate question, but this linter would not report the following piece of code:

```
const MyComponent = () => <StyledSpan onClick={() => console.log("Hello")}>Hello</StyledSpan>;
const StyledSpan = styled.span``;
```

## The reason

We're parsing elements in the jsx file one after another, adding styled components to the styled component map and comparing new occurrences with that map. With such approach, the use-before-define styled components will not be detected by the time we find an occurrence and the linter will treat it as custom React components that are not checked.

## The change

Now we're processing the list of components after we have gone through the entire file. I have also added 2 tests that were failing before my change. 

All tests pass.