### PR TITLE
Support custom components to element mapping

### DIFF
--- a/__tests__/rules/alt-text.test.js
+++ b/__tests__/rules/alt-text.test.js
@@ -33,8 +33,6 @@ const areaError =
 
 const inputImageError =
   '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.';
-const imgAltTextError =
-  'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.';
 
 const ruleName = 'alt-text';
 const rule = makeRule(ruleName);
@@ -222,14 +220,12 @@ const imgAriaLabelStr = makeStyledTestCases({
   props: 'aria-label="foo"',
   attrs: '{ "aria-label": "foo" }',
   tag: 'img',
-  errors: [imgAltTextError],
 });
 // { code: '<img aria-labelledby="id1" />' },
 const imgAriaLabelByStr = makeStyledTestCases({
   props: 'aria-labelledby="id1"',
   attrs: '{ "aria-labelledby": "id1" }',
   tag: 'img',
-  errors: [imgAltTextError],
 });
 
 // ## INVALID

--- a/__tests__/rules/alt-text.test.js
+++ b/__tests__/rules/alt-text.test.js
@@ -217,6 +217,20 @@ const imgAltObjPropPlusStr = makeStyledTestCases({
   attrs: '{ alt: plugin.name + " Logo" }',
   tag: 'img',
 });
+// { code: '<img aria-label="foo" />' },
+const imgAriaLabelStr = makeStyledTestCases({
+  props: 'aria-label="foo"',
+  attrs: '{ "aria-label": "foo" }',
+  tag: 'img',
+  errors: [imgAltTextError],
+});
+// { code: '<img aria-labelledby="id1" />' },
+const imgAriaLabelByStr = makeStyledTestCases({
+  props: 'aria-labelledby="id1"',
+  attrs: '{ "aria-labelledby": "id1" }',
+  tag: 'img',
+  errors: [imgAltTextError],
+});
 
 // ## INVALID
 //     { code: '<img />;', errors: [missingPropError('img')] },
@@ -291,22 +305,6 @@ const inputTypeImagePropsSpread = makeStyledTestCases({
   errors: [inputImageError],
 });
 
-// { code: '<img aria-label="foo" />' },
-const imgAriaLabelStr = makeStyledTestCases({
-  props: 'aria-label="foo"',
-  attrs: '{ "aria-label": "foo" }',
-  tag: 'img',
-  errors: [imgAltTextError],
-});
-
-// { code: '<img aria-labelledby="id1" />' },
-const imgAriaLabelByStr = makeStyledTestCases({
-  props: 'aria-labelledby="id1"',
-  attrs: '{ "aria-labelledby": "id1" }',
-  tag: 'img',
-  errors: [imgAltTextError],
-});
-
 ruleTester.run(ruleName, rule, {
   valid: [
     ...ImgAltStr,
@@ -338,6 +336,8 @@ ruleTester.run(ruleName, rule, {
     ...imgAltTernaryObjStrStr,
     ...imgAltTernaryUndefinedStrStr,
     ...imgAltObjPropPlusStr,
+    ...imgAriaLabelStr,
+    ...imgAriaLabelByStr,
   ],
   invalid: [
     ...imgNoAlt,
@@ -350,7 +350,5 @@ ruleTester.run(ruleName, rule, {
     ...objectPropsSpread,
     ...areaPropsSpread,
     ...inputTypeImagePropsSpread,
-    ...imgAriaLabelStr,
-    ...imgAriaLabelByStr,
   ],
 });

--- a/__tests__/rules/anchor-is-valid.test.js
+++ b/__tests__/rules/anchor-is-valid.test.js
@@ -7,13 +7,13 @@ const ruleName = 'anchor-is-valid';
 const rule = makeRule(ruleName);
 
 const preferButtonErrorMessage =
-  'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
+  'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md';
 
 const noHrefErrorMessage =
-  'The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
+  'The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md';
 
 const invalidHrefErrorMessage =
-  'The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md';
+  'The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md';
 
 const preferButtonexpectedError = {
   message: preferButtonErrorMessage,

--- a/__tests__/rules/aria-activedescendant-has-tabindex.test.js
+++ b/__tests__/rules/aria-activedescendant-has-tabindex.test.js
@@ -4,7 +4,7 @@ const ruleTester = new RuleTester();
 const makeStyledTestCases = require('../utils/makeStyledTestCases');
 
 const expectedError = {
-  message: 'An element that manages focus with `aria-activedescendant` must be tabbable',
+  message: 'An element that manages focus with `aria-activedescendant` must have a tabindex',
   type: 'JSXOpeningElement',
 };
 
@@ -72,6 +72,24 @@ const inputAriaActivedescendantJsxVarTabIndexZero = makeStyledTestCases({
   props: 'aria-activedescendant={someID} tabIndex={0}',
   tag: 'input',
 });
+// <div aria-activedescendant={someID} tabIndex={-1} />
+const divAriaActiveDescendantNegativeTabIndex = makeStyledTestCases({
+  attrs: "{ 'aria-activedescendant':someID, tabIndex:-1 }",
+  props: 'aria-activedescendant={someID} tabIndex={-1}',
+  tag: 'div',
+});
+// <div aria-activedescendant={someID} tabIndex="-1" />
+const divAriaActiveDescendantNegativeTabIndexString = makeStyledTestCases({
+  attrs: `{ 'aria-activedescendant':someID, tabIndex:"-1" }`,
+  props: 'aria-activedescendant={someID} tabIndex="-1"',
+  tag: 'div',
+});
+// <input aria-activedescendant={someID} tabIndex={-1} />
+const inputAriaActiveDescendantNegative = makeStyledTestCases({
+  attrs: `{ 'aria-activedescendant':someID, tabIndex:-1 }`,
+  props: 'aria-activedescendant={someID} tabIndex={-1}',
+  tag: 'input',
+});
 
 //  ##INVALID
 // <div aria-activedescendant={someID} />
@@ -79,27 +97,6 @@ const divAriaActiveDescendant = makeStyledTestCases({
   attrs: "{ 'aria-activedescendant':someID }",
   props: 'aria-activedescendant={someID}',
   tag: 'div',
-  errors: [expectedError],
-});
-// <div aria-activedescendant={someID} tabIndex={-1} />
-const divAriaActiveDescendantNegativeTabIndex = makeStyledTestCases({
-  attrs: "{ 'aria-activedescendant':someID, tabIndex:-1 }",
-  props: 'aria-activedescendant={someID} tabIndex={-1}',
-  tag: 'div',
-  errors: [expectedError],
-});
-// <div aria-activedescendant={someID} tabIndex="-1" />
-const divAriaActiveDescendantNegativeTabIndexString = makeStyledTestCases({
-  attrs: `{ 'aria-activedescendant':someID, tabIndex:"-1" }`,
-  props: 'aria-activedescendant={someID} tabIndex="-1"',
-  tag: 'div',
-  errors: [expectedError],
-});
-// <input aria-activedescendant={someID} tabIndex={-1} />
-const inputAriaActiveDescendantNegative = makeStyledTestCases({
-  attrs: `{ 'aria-activedescendant':someID, tabIndex:-1 }`,
-  props: 'aria-activedescendant={someID} tabIndex={-1}',
-  tag: 'input',
   errors: [expectedError],
 });
 
@@ -117,11 +114,11 @@ ruleTester.run(ruleName, rule, {
     ...divAriaActivedescendantJsxVarTabIndexOne,
     ...inputAriaActivedescendantJsxVar,
     ...inputAriaActivedescendantJsxVarTabIndexZero,
-  ],
-  invalid: [
-    ...divAriaActiveDescendant,
     ...divAriaActiveDescendantNegativeTabIndex,
     ...divAriaActiveDescendantNegativeTabIndexString,
     ...inputAriaActiveDescendantNegative,
+  ],
+  invalid: [
+    ...divAriaActiveDescendant,
   ],
 });

--- a/__tests__/rules/no-access-key.test.js
+++ b/__tests__/rules/no-access-key.test.js
@@ -10,7 +10,7 @@ const ruleName = 'no-access-key';
 const rule = makeRule(ruleName);
 
 const errorMessage =
-  'No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard comments used by screenreader and keyboard only users create a11y complications.';
+  'No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.';
 
 // ## VALID
 const noAccessKey = makeStyledTestCases();

--- a/__tests__/rules/no-static-element-interactions.test.js
+++ b/__tests__/rules/no-static-element-interactions.test.js
@@ -9,7 +9,7 @@ const makeStyledTestCases = require('../utils/makeStyledTestCases');
 const ruleName = 'no-static-element-interactions';
 const rule = makeRule(ruleName);
 
-const expectedError = 'Static HTML elements with event handlers require a role.';
+const expectedError = 'Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element.';
 
 // ## VALID
 // <button onClick={() => 0} className="foo" />

--- a/__tests__/utils/parserOptionsMapper.js
+++ b/__tests__/utils/parserOptionsMapper.js
@@ -6,7 +6,7 @@ const defaultParserOptions = {
   },
 };
 
-module.exports = function parserOptionsMapper({ code, errors, options = [], parserOptions = {} }) {
+module.exports = function parserOptionsMapper({ code, errors, options = [], parserOptions = {}, settings = {} }) {
   return {
     code,
     errors,
@@ -15,5 +15,6 @@ module.exports = function parserOptionsMapper({ code, errors, options = [], pars
       ...defaultParserOptions,
       ...parserOptions,
     },
+    settings,
   };
 };

--- a/playground/.eslintrc.js
+++ b/playground/.eslintrc.js
@@ -10,6 +10,13 @@ module.exports = {
     es6: true,
     browser: true,
   },
+  settings: {
+    "jsx-a11y": {
+      components: {
+        ImgComponent: 'img',
+      },
+    },
+  },
   rules: {
     'react/jsx-filename-extension': 0,
   },


### PR DESCRIPTION
Support to checking as specified element for Custom Components.:fire:
This follows settings of [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#usage).

```js
// .eslintrc.js
settings: {
  "jsx-a11y": {
    components: {
      ImgComponent: 'img',
    },
  },
},
```

```jsx
const ImgComponent = ({ alt }) => <img alt={alt} />;

const StyledImg = styled(ImgComponent)``;

{/* Recognized as an img element and detect an error that img elements must have an alt prop! */}
<StyledImg />
```

In addition, some failing tests due to an upgrade of eslint-plugin-jsx-a11y have been fixed. :)

 - Some error messages have changed.
 - Alt is not required if aria-label or aria-labelledby is specified (alt-text.test).
 - Negative indexes are allowed now (aria-activedescendant-has-tabindex).