### PR TITLE
Add peer dependency on eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "jest": "^25.1.0",
     "jsx-ast-utils": "^3.3.2",
     "nodemon": "^2.0.2"
+  },
+  "peerDependencies": {
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
   }
 }


### PR DESCRIPTION
`eslint-plugin-styled-components-a11y` is missing a `peerDependencies` on `eslint`, as transitively requested by `eslint-plugin-jsx-a11y`.

While it's not a massive problem, it does make life harder for package managers when trying to optimize package installation, see [Implicit Transitive Peer Dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

yarn currently reports as so:
```
eslint-plugin-styled-components-a11y@npm:2.1.3 doesn't provide eslint, breaking the following requirements:
eslint-plugin-jsx-a11y@npm:6.7.1 → ^3 || ^4 || ^5 || ^6 || ^7 || ^8
```