### PR TITLE
fix(config): fix undefined parserOptions in flat config

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "css in js"
   ],
   "author": "https://github.com/brendanmorrell",
+  "repository": {
+    "url": "https://github.com/brendanmorrell/eslint-plugin-styled-components-a11y",
+    "type": "git"
+  },
   "license": "ISC",
   "dependencies": {
     "@babel/parser": "^7.8.4",

--- a/src/index.js
+++ b/src/index.js
@@ -43,15 +43,17 @@ const pluginBase = {
   },
 };
 
+const parserOptions = {
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
 const configs = {
   recommended: {
     plugins: ['styled-components-a11y'],
     extends: ['plugin:jsx-a11y/recommended'],
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true,
-      },
-    },
+    parserOptions,
     rules: {
       'styled-components-a11y/alt-text': 'error',
       'styled-components-a11y/anchor-has-content': 'error',
@@ -153,11 +155,7 @@ const configs = {
   strict: {
     plugins: ['styled-components-a11y'],
     extends: ['plugin:jsx-a11y/strict'],
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true,
-      },
-    },
+    parserOptions,
     rules: {
       'styled-components-a11y/alt-text': 'error',
       'styled-components-a11y/anchor-has-content': 'error',
@@ -237,8 +235,8 @@ const configs = {
 };
 
 const flatConfigBase = {
-  languageOptions: { parserOptions: configs.parserOptions },
   plugins: { 'styled-components-a11y': pluginBase },
+  languageOptions: { parserOptions },
 };
 
 module.exports = {


### PR DESCRIPTION
I experienced an issue where this caused the config to be invalid due to the `parserOptions` property not existing on the `flatConfigBase` object.

This PR adds a `parserOptions` object to the top level and uses it in the flat configs and legacy configs in the appropriate places.

This PR also adds the missing repository info to the package.json. 

Note that this does not do a version bump or modify the changelog. If you'd like me to do that, please let me know :) 