### PR TITLE
feat: Add support for object syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds the ability to lint styled components according to the rules outlined in eslint-plugin-jsx-a11y.
 
-It handles all 5 methods styled components uses to create components. All of these would show the error
+It handles all 7 methods styled components uses to create components. All of these would show the error
 
 ```diff
 -Visible, non-interactive elements with click handlers must have at least one keyboard listener.`
@@ -32,6 +32,16 @@ const StyledDiv = styled(Div)``;
 ```jsx
 const ButtonAsDiv = styled.button``;
 <ButtonAsDiv as="div" onClick={() => null} />;
+```
+
+```jsx
+const ButtonAsDiv = styled.button({});
+<ButtonAsDiv as="div" onClick={() => null} />;
+```
+
+```jsx
+const CustomComponent = styled(Component)({});
+<CustomComponent />;
 ```
 
 Elements can also be defined within objects:

--- a/Todo.md
+++ b/Todo.md
@@ -48,7 +48,6 @@ function Foo(props) {
 - the value for template literals is definitely bullshit. need to evaluate the tree to figure out how to handle
 - need a way to make sure plugin doesnt crash eslint regardless of parsing difficulties
 - need to set tests to handle more varietes of keys/values, specifically should have at least handle everything surrounded by all types of string quotes
-- add support for object syntax (const Button = styled.button({ color: 'blue' }));
 - add optional params to change the name from styled
 
 ## tests to revisit (first four mimic actual tests instead of npm docs.)

--- a/__tests__/utils/makeStyledTestCases.js
+++ b/__tests__/utils/makeStyledTestCases.js
@@ -34,6 +34,20 @@ const withStringArgument = ({ tag, props, children, siblings }) =>
     children ? `<>${siblings}<STYLED ${props}>${children}</STYLED></>` : `<>${siblings}<STYLED ${props} /></>`
   };
 `;
+const withObjectArgument = ({ tag, props, children, siblings }) =>
+  `
+  const STYLED = styled('${tag}')({ color: 'blue' });
+  const Func = () => ${
+    children ? `<>${siblings}<STYLED ${props}>${children}</STYLED></>` : `<>${siblings}<STYLED ${props} /></>`
+  };
+`;
+const withObjectArgumentAsExpression = ({ tag, props, children, siblings }) =>
+  `
+  const STYLED = styled.${tag}({ color: 'blue' });
+  const Func = () => ${
+    children ? `<>${siblings}<STYLED ${props}>${children}</STYLED></>` : `<>${siblings}<STYLED ${props} /></>`
+  };
+`;
 const withCombinedComponentObject = ({ tag, props, children, siblings }) =>
   `
   const STYLED = styled(animated.${tag})\`\`;
@@ -139,6 +153,14 @@ const withCustomComponent = ({ tag, props, children, siblings }) =>
   };
 `;
 
+const withCustomComponentAndObject = ({ tag, props, children, siblings }) =>
+  `
+  const STYLED = styled(${getCustomComponentName(tag)})({});
+  const Func = () => ${
+    children ? `<>${siblings}<STYLED ${props}>${children}</STYLED></>` : `<>${siblings}<STYLED ${props} /></>`
+  };
+`;
+
 const withCustomComponentAttrs = ({ tag, attrs, children, siblings }) =>
   `
   const STYLED = styled(${getCustomComponentName(tag)}).attrs(${attrs})\`\`;
@@ -150,6 +172,8 @@ const makeStyledTestCases = (args) =>
     regular,
     regularAsObject,
     withStringArgument,
+    withObjectArgument,
+    withObjectArgumentAsExpression,
     withCombinedComponentObject,
     withStyledAttrs,
     withStringArgumentAndAttrs,
@@ -162,6 +186,7 @@ const makeStyledTestCases = (args) =>
     withStyledComponentsAsOtherWithComponentDefinedAfterInstantiation,
     withStringArgumentStyledComponentsAsOtherWithComponentDefinedAfterInstantiation,
     withCustomComponent,
+    withCustomComponentAndObject,
     withCustomComponentAttrs,
   ]
     .map(makeRuleMaker)

--- a/src/utils/collectStyledComponentData.js
+++ b/src/utils/collectStyledComponentData.js
@@ -1,4 +1,9 @@
-const isStyledCallExpression = (node) => node.tag.type === 'CallExpression';
+/**
+ *
+ * @param {import('estree').Expression} node
+ * @returns  {node is import('estree').CallExpression}
+ */
+const isStyledCallExpression = (tag) => tag?.type === 'CallExpression';
 const isStyledFunc = (node) => node.tag.callee?.name === 'styled';
 const isStyledFuncComponentArgument = (node) => isStyledFunc(node) && node.tag.arguments?.[0]?.type === 'Identifier';
 const isStyledFuncStringArgument = (node) => isStyledFunc(node) && node.tag.arguments?.[0]?.type === 'Literal';
@@ -10,8 +15,24 @@ const isStyledComponentArgumentFuncWithAttrs = (node) =>
   isStyledFuncWithAttrs(node) && node.tag.callee?.object?.arguments?.[0]?.type === 'Identifier';
 
 const styledCallElementObjectMapArgumentTag = (node) => node.tag?.arguments?.[0]?.property?.name;
-
-const isPlainSTE = (node) => node.tag.type === 'MemberExpression' && node.tag?.object?.name === 'styled';
+/**
+ *
+ * @param {import('eslint').Rule.Node | null | undefined} node
+ * @returns  {node is import('estree').Identifier}
+ */
+const isIdentifier = (node) => node?.type === 'Identifier';
+/**
+ *
+ * @param {import('eslint').Rule.Node | null | undefined} node
+ * @returns  {node is import('estree').Identifier}
+ */
+const isStyledIdentifier = (node) => isIdentifier(node) && node.name === 'styled';
+/**
+ *
+ * @param {import('estree').TaggedTemplateExpression | null | undefined} node
+ * @returns  {boolean}
+ */
+const isPlainSTE = (node) => node.tag.type === 'MemberExpression' && isStyledIdentifier(node.tag?.object);
 const isAttrs = ({ tag }) => tag.callee?.property?.name === 'attrs';
 
 const getAttrsType = (node) => {
@@ -27,127 +48,244 @@ const getAttrsType = (node) => {
 const { inspect } = require('util');
 const { __UNKNOWN_IDENTIFER__ } = require('./constants');
 
-module.exports = (styledComponentsDict, context, name) => ({
-  TaggedTemplateExpression(node) {
-    const func = (inspectee) =>
-      name.includes('html-has-lang') && context.report(node, `made it here: ${inspect(inspectee || node)}`);
-    let scName = node.parent.id && node.parent.id.name;
+/**
+ *
+ * @param {Record<string, {name: string; attrs: any[]; tag: string}>} styledComponentsDict
+ * @param {import('eslint').Rule.RuleContext} context
+ * @param {string} name
+ * @returns {import('eslint').Rule.RuleListener}
+ */
+module.exports = (styledComponentsDict, context, name) => {
+  /**
+   * enable checking custom components
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#usage
+   */
+  const componentMap = context.settings?.['jsx-a11y']?.components ?? {};
 
-    if (!scName) {
-      if (isPlainSTE(node) && node.parent.key?.name && node.parent.parent?.parent?.id?.name) {
-        scName = `${node.parent.parent.parent.id.name}.${node.parent.key.name}`;
-      } else {
-        return;
-      }
-    }
-
-    let attrs = [];
-    let tag = '';
-
-    // styled(Component)`` || styled.div.attrs(...)`` || styled('div')``
-    if (isStyledCallExpression(node)) {
-      // styled(animated.div)``
-      if (styledCallElementObjectMapArgumentTag(node)) {
-        tag = styledCallElementObjectMapArgumentTag(node);
-      }
-      // styled('div')``;
-      else if (isStyledFuncStringArgument(node)) {
-        tag = node.tag.arguments?.[0]?.value || '';
-      }
-
-      // styled(Component)`` || styled(Component).attrs(...)``
-      if (isStyledFuncComponentArgument(node) || isStyledComponentArgumentFuncWithAttrs(node)) {
-        const ancestorScName = isStyledFuncComponentArgument(node)
-          ? node.tag.arguments[0].name
-          : node.tag.callee.object.arguments[0].name;
-
-        /**
-         * enable checking custom components
-         * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#usage
-         */
-        const componentMap = context.settings?.['jsx-a11y']?.components ?? {};
-
-        // styled(StyledComponent)`` || styled(StyledComponent).attrs(...)``
-        if (styledComponentsDict[ancestorScName]) {
-          ({ attrs } = styledComponentsDict[ancestorScName]);
-          ({ tag } = styledComponentsDict[ancestorScName]);
+  return {
+    CallExpression: function CallExpression(node) {
+      try {
+        // TODO: Consider supporting more complex parent name definitions (e.g. object keys)
+        let styledComponentName =
+          node.parent && 'id' in node.parent && node.parent.id?.type === 'Identifier' ? node.parent.id.name : null;
+        if (!styledComponentName) {
+          // const Components = { Component: styled.div({ ... }) }
+          if (
+            node.parent.type === 'Property' &&
+            isIdentifier(node.parent.key) &&
+            node.parent.key.name &&
+            node.parent.parent?.parent?.type === 'VariableDeclarator' &&
+            isIdentifier(node.parent.parent.parent.id) &&
+            node.parent.parent.parent.id.name
+          ) {
+            styledComponentName = `${node.parent.parent.parent.id.name}.${node.parent.key.name}`;
+          } else {
+            return;
+          }
         }
 
-        // styled(CustomComponent)`` || styled(CustomComponent).attrs(...)``
-        if (componentMap[ancestorScName]) {
-          tag = componentMap[ancestorScName];
+        let tag = '';
+
+        if (!styledComponentName) return;
+
+        // styled.?({ ... })
+        if (node.callee?.type === 'MemberExpression' && isStyledIdentifier(node.callee.object)) {
+          // styled.div({ ... })
+          if (node.callee.property?.type === 'Identifier' && node.callee.property.name) {
+            tag = node.callee.property.name;
+
+            if (!tag) return;
+
+            styledComponentsDict[styledComponentName] = {
+              name: styledComponentName,
+              attrs: [],
+              tag: tag,
+            };
+          }
+        }
+
+        // styled(...)(...)
+        if (node.callee?.type === 'CallExpression' && isStyledIdentifier(node.callee.callee)) {
+          let arg = node.callee.arguments[0];
+
+          if (!arg) return;
+
+          // styled('div')(...)
+          if (arg.type === 'Literal') {
+            tag = arg.value;
+
+            if (!tag) return;
+
+            styledComponentsDict[styledComponentName] = {
+              name: styledComponentName,
+              attrs: [],
+              tag: tag,
+            };
+          }
+
+          // TODO: Consider supporting templates like styled(`div`)(...)
+          if (arg.type !== 'Identifier') return;
+
+          // styled(StyledComponent)({ ... })
+
+          let attrs = [];
+          let ancestorScName = arg.name;
+
+          if (styledComponentsDict[ancestorScName]) {
+            // Add attrs if the ancestor has them
+            attrs = styledComponentsDict[ancestorScName].attrs;
+            tag = styledComponentsDict[ancestorScName].tag;
+          }
+
+          // styled(CustomComponent)({ ...})
+          if (componentMap[ancestorScName]) {
+            tag = componentMap[ancestorScName];
+          }
+
+          if (!tag) return;
+
+          styledComponentsDict[styledComponentName] = {
+            name: styledComponentName,
+            attrs: attrs,
+            tag: tag,
+          };
+        }
+      } catch (error) {
+        context.report({
+          message: 'Unable to parse styled component: {{ message }}',
+          node,
+          data: { message: error.message, stack: error.stack },
+        });
+      }
+    },
+    TaggedTemplateExpression(node) {
+      const func = (inspectee) =>
+        name.includes('html-has-lang') && context.report(node, `made it here: ${inspect(inspectee || node)}`);
+      let scName = node.parent.id && node.parent.id.name;
+
+      if (!scName) {
+        // const Components = { Component: styled.div`` }
+        if (
+          node.tag.type === 'MemberExpression' &&
+          isStyledIdentifier(node.tag?.object) &&
+          node.parent.type === 'Property' &&
+          isIdentifier(node.parent.key) &&
+          node.parent.key.name &&
+          node.parent.parent?.parent?.type === 'VariableDeclarator' &&
+          isIdentifier(node.parent.parent.parent.id) &&
+          node.parent.parent.parent.id.name
+        ) {
+          scName = `${node.parent.parent.parent.id.name}.${node.parent.key.name}`;
+        } else {
+          return;
         }
       }
 
-      // styled.div.attrs(...)`` || styled(Component).attrs(...)`` || styled('div').attrs(...)``
-      if (isAttrs(node) || isStyledFuncWithAttrs(node)) {
-        let attrsPropertiesArr = [];
-        const attrsNode = node.tag.arguments[0];
+      let attrs = [];
+      let tag = '';
 
-        if (isStyledStringArgumentFuncWithAttrs(node)) {
-          tag = node.tag.callee?.object?.arguments?.[0]?.value;
-        } else if (!isStyledComponentArgumentFuncWithAttrs(node)) {
-          tag = node.tag.callee.object.property?.name;
+      // styled(Component)`` || styled.div.attrs(...)`` || styled('div')``
+      if (isStyledCallExpression(node.tag)) {
+        // styled(animated.div)``
+        if (styledCallElementObjectMapArgumentTag(node)) {
+          tag = styledCallElementObjectMapArgumentTag(node);
         }
-        const attrsType = getAttrsType(node);
-        if (!tag || !attrsType) return;
-        // styled.div.attrs(function() { return {} })``
-
-        // TODO all these empty array defaults are a temp fix. Should get a better way of actually trying to see what
-        //  is returned from function attrs in the case they aren't just simple immediate returns, e.g., if else statements
-        if (attrsType === 'arrow') {
-          attrsPropertiesArr = attrsNode?.body?.properties || [];
-          // styled.div.attrs(() => ({}))``
-        } else if (attrsType === 'func') {
-          attrsPropertiesArr =
-            attrsNode?.body?.body?.find((x) => x.type === 'ReturnStatement')?.argument?.properties || [];
-          // styled.div.attrs({})``
-        } else if (attrsType === 'object') {
-          attrsPropertiesArr = attrsNode?.properties || [];
+        // styled('div')``;
+        else if (isStyledFuncStringArgument(node)) {
+          tag = node.tag.arguments?.[0]?.value || '';
         }
 
-        const arithmeticUnaryOperators = ['+', '-'];
-        // filter out spread elements (which have no key nor value)
-        attrs = attrs.concat(
-          attrsPropertiesArr
-            .filter((x) => x.key)
-            .map((x) => ({
-              key: x.key.name || x.key.value,
-              // this is pretty useless. would need to generate code from any template expression for this to really work
-              value:
-                x.value.type === 'TemplateLiteral'
-                  ? // need to grab falsy vals like empty strings, thus the x ? x : identifier instead of x|| identifier
-                    typeof x.value.quasis[0].value.raw === 'undefined'
-                    ? __UNKNOWN_IDENTIFER__
-                    : x.value.quasis[0].value.raw
-                  : x.value.type === 'UnaryExpression' && arithmeticUnaryOperators.includes(x.value.operator)
-                  ? // if simple arithemetic, concat the symbol and the strings (like a negative) and then coerce to a number
-                    +(x.value.operator + x.value.argument.value)
-                  : x.value.type === 'Identifier'
-                  ? x.value.name === 'undefined'
-                    ? undefined
-                    : __UNKNOWN_IDENTIFER__
-                  : typeof x.value.value === 'undefined'
-                  ? // if property exists, but no value found, just set it to our unknown identifier so it returns truthy and not something specific like a number or boolean or undefined as these are tested in specific ways for different linting rules
-                    // too many options for what this could be, but this can approxinate what is needed for linting
-                    // need to grab falsy vals like empty strings, thus the x ? x : identifier instead of x|| identifier
-                    __UNKNOWN_IDENTIFER__
-                  : x.value.value,
-            })),
-        );
+        // styled(Component)`` || styled(Component).attrs(...)``
+        if (isStyledFuncComponentArgument(node) || isStyledComponentArgumentFuncWithAttrs(node)) {
+          const ancestorScName = isStyledFuncComponentArgument(node)
+            ? node.tag.arguments[0].name
+            : node.tag.callee.object.arguments[0].name;
+
+          // styled(StyledComponent)`` || styled(StyledComponent).attrs(...)``
+          if (styledComponentsDict[ancestorScName]) {
+            ({ attrs } = styledComponentsDict[ancestorScName]);
+            ({ tag } = styledComponentsDict[ancestorScName]);
+          }
+
+          // styled(CustomComponent)`` || styled(CustomComponent).attrs(...)``
+          if (componentMap[ancestorScName]) {
+            tag = componentMap[ancestorScName];
+          }
+        }
+
+        // styled.div.attrs(...)`` || styled(Component).attrs(...)`` || styled('div').attrs(...)``
+        if (isAttrs(node) || isStyledFuncWithAttrs(node)) {
+          let attrsPropertiesArr = [];
+          const attrsNode = node.tag.arguments[0];
+
+          if (isStyledStringArgumentFuncWithAttrs(node)) {
+            tag = node.tag.callee?.object?.arguments?.[0]?.value;
+          } else if (!isStyledComponentArgumentFuncWithAttrs(node)) {
+            tag = node.tag.callee.object.property?.name;
+          }
+          const attrsType = getAttrsType(node);
+          if (!tag || !attrsType) return;
+          // styled.div.attrs(function() { return {} })``
+
+          // TODO all these empty array defaults are a temp fix. Should get a better way of actually trying to see what
+          //  is returned from function attrs in the case they aren't just simple immediate returns, e.g., if else statements
+          if (attrsType === 'arrow') {
+            attrsPropertiesArr = attrsNode?.body?.properties || [];
+            // styled.div.attrs(() => ({}))``
+          } else if (attrsType === 'func') {
+            attrsPropertiesArr =
+              attrsNode?.body?.body?.find((x) => x.type === 'ReturnStatement')?.argument?.properties || [];
+            // styled.div.attrs({})``
+          } else if (attrsType === 'object') {
+            attrsPropertiesArr = attrsNode?.properties || [];
+          }
+
+          const arithmeticUnaryOperators = ['+', '-'];
+          // filter out spread elements (which have no key nor value)
+          attrs = attrs.concat(
+            attrsPropertiesArr
+              .filter((x) => x.key)
+              .map((x) => ({
+                key: x.key.name || x.key.value,
+                // this is pretty useless. would need to generate code from any template expression for this to really work
+                value:
+                  x.value.type === 'TemplateLiteral'
+                    ? // need to grab falsy vals like empty strings, thus the x ? x : identifier instead of x|| identifier
+                      typeof x.value.quasis[0].value.raw === 'undefined'
+                      ? __UNKNOWN_IDENTIFER__
+                      : x.value.quasis[0].value.raw
+                    : x.value.type === 'UnaryExpression' && arithmeticUnaryOperators.includes(x.value.operator)
+                    ? // if simple arithemetic, concat the symbol and the strings (like a negative) and then coerce to a number
+                      +(x.value.operator + x.value.argument.value)
+                    : x.value.type === 'Identifier'
+                    ? x.value.name === 'undefined'
+                      ? undefined
+                      : __UNKNOWN_IDENTIFER__
+                    : typeof x.value.value === 'undefined'
+                    ? // if property exists, but no value found, just set it to our unknown identifier so it returns truthy and not something specific like a number or boolean or undefined as these are tested in specific ways for different linting rules
+                      // too many options for what this could be, but this can approxinate what is needed for linting
+                      // need to grab falsy vals like empty strings, thus the x ? x : identifier instead of x|| identifier
+                      __UNKNOWN_IDENTIFER__
+                    : x.value.value,
+              })),
+          );
+        }
+
+        styledComponentsDict[scName] = { name: scName, attrs, tag };
       }
 
-      styledComponentsDict[scName] = { name: scName, attrs, tag };
-    }
+      // const A = styled.div``
+      if (node.tag.type === 'MemberExpression' && isStyledIdentifier(node.tag?.object)) {
+        tag = 'name' in node.tag.property ? node.tag.property.name : '';
 
-    // const A = styled.div``
-    if (isPlainSTE(node)) {
-      tag = node.tag.property.name;
-      styledComponentsDict[scName] = {
-        name: scName,
-        tag,
-        attrs,
-      };
-    }
-  },
-});
+        if (!tag) return;
+
+        styledComponentsDict[scName] = {
+          name: scName,
+          tag,
+          attrs,
+        };
+      }
+    },
+  };
+};


### PR DESCRIPTION
We primarily use object syntax with Emotion so hoping to check this off the TODO list.

This work should support the primary syntaxes supported by `emotion` and others and add appropriate tests.

Examples:

```
const ButtonAsDiv = styled.button({});
<ButtonAsDiv as="div" onClick={() => null} />;
```

```jsx
const CustomComponent = styled(Component)({});
<CustomComponent />;
```

Emotion [doesn't support attrs](https://github.com/emotion-js/emotion/issues/821), and not sure on the state of object + attrs syntax elsewhere so I haven't added it here.

This is a super helpful eslint plugin, cheers 🎉 